### PR TITLE
Workaround for 19.41 failed support

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,3 +4,7 @@ c_compiler:    # [win]
 - vs2022       # [win]
 cxx_compiler:  # [win]
 - vs2022       # [win]
+# Workaround addressing https://github.com/conda-forge/vc-feedstock/issues/83
+cxx_compiler_version:  # [win]
+  - 19.40              # [win]
+  


### PR DESCRIPTION
Local workaround for the failing Azure pipelines. 

Bug reported in https://github.com/conda-forge/vc-feedstock/issues/83

Workaround proposed in https://github.com/conda-forge/vc-feedstock/issues/83#issuecomment-2339943983

Since Azure images keep changing, according to https://github.com/conda-forge/vc-feedstock/issues/83#issuecomment-2340034565, the pipeline may still fail, but should run okay after some re-renders.