### PR TITLE
Fix feedstock

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "power-grid-model" %}
-{% set version = "1.10.18" %}
+{% set version = "1.10.29" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/b9/99/7fc791fe42fdd73566c235b7f969297a1dcfdc1409bf05fe8897402191b4/power_grid_model-{{ version }}.tar.gz
-  sha256: fd15439166cabfe36a34854b9aa789d2d4ace985950780e13cb852ebafb8659a
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: d4a04f95a7a4cc92f2f4e178fbf5c1729c0469df9fdae75bd1eb2f061bf2e74e
 
 build:
   skip: true  # [py<310 or win32 or ppc64le or (python_impl == 'pypy')]


### PR DESCRIPTION
This attempts to fix feedstock:

- [x] Starting with #303, the way to retrieve versions via PyPI was changed without explanation by the bot, which after #304 seemed to affect the bot not being triggered. This serves as the first part to attempt to fix this.

Closes #307 
Closes #306 